### PR TITLE
Version agnostic dict encoding fix

### DIFF
--- a/src/bert.erl
+++ b/src/bert.erl
@@ -34,7 +34,7 @@ encode_term(Term) ->
     [] -> {bert, nil};
     true -> {bert, true};
     false -> {bert, false};
-    Dict when is_record(Term, dict, 8) ->
+    Dict when is_tuple(Term) andalso element(1, Term) =:= dict ->
       {bert, dict, dict:to_list(Dict)};
     List when is_list(Term) ->
       lists:map((fun encode_term/1), List);

--- a/test/bert_test.erl
+++ b/test/bert_test.erl
@@ -10,6 +10,11 @@ encode_tuple_nesting_test() ->
   Bert = term_to_binary({foo, {bert, true}}),
   Bert = encode({foo, true}).
 
+encode_dict_test() ->
+  Bert = term_to_binary({ bert, dict,
+                          dict:to_list(dict:store(foo, true, dict:new())) }),
+  Bert = encode(dict:store(foo, true, dict:new())).
+
 %% decode
 
 decode_list_nesting_test() ->
@@ -21,3 +26,10 @@ decode_tuple_nesting_test() ->
   Bert = term_to_binary({foo, {bert, true}}),
   Term = {foo, true},
   Term = decode(Bert).
+
+decode_dict_test() ->
+  Bert = term_to_binary({ bert, dict,
+                          dict:to_list(dict:store(foo, true, dict:new())) }),
+  Term = dict:store(foo, true, dict:new()),
+  Term = decode(Bert).
+


### PR DESCRIPTION
Dict encoding won't work on approx. greater than R13B03 due to dict internal representation changing from a tuple of size 8 to size 9 (assuming it worked in the past, which I haven't verified). This sidesteps the issue and checks for a tuple whose first element is `dict`
